### PR TITLE
feat(sprint-5): pipeline state, TTS plugins, production report

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -65,3 +65,20 @@ Result: Sprint 2 est implémenté. PR ouverte : **https://github.com/imagodata/n
 - Crée: `config.yaml`, `sequences/__init__.py`, `sequences/seq00_intro.py`, `narrations/<lang>.yaml`, `diagrams/definitions.py`
 
 **Issue #4 — Config schema validat
+
+
+## [2026-03-23 15:15]
+Delegate task: narractive continuer les prochaines implementations et close les issues terminées
+Result: ## Résumé
+
+**Tâche 1 — Sprint 3 clôturé ✅**
+- PR #18 mergée
+- Issues #6, #7, #8 fermées
+
+**Tâche 2 — Sprint 4 implémenté ✅**
+
+| Issue | Feature | Implémentation |
+|-------|---------|----------------|
+| #9 | **Chapter markers MP4** | `VideoAssembler.add_chapter_markers()` via FFMETADATA + `-map_chapters` |
+| #10 | **WebVTT subtitles** | `generate_vtt()` + `format_vtt_timestamp()` dans `subtitles.py`, flag `generate_webvtt=True` |
+| #11 | **Intro/outro video clips** | `add_intro_outro()` étendu av

--- a/examples/custom_tts_plugin.py
+++ b/examples/custom_tts_plugin.py
@@ -1,0 +1,110 @@
+"""
+Custom TTS Engine Plugin Example
+=================================
+This file demonstrates how to write a custom TTS engine for Narractive.
+
+Usage
+-----
+1. Define a subclass of :class:`TTSEngine` with a unique ``engine_name``.
+2. Implement the :meth:`generate` method.
+3. Register the engine at startup (e.g. in a ``conftest.py``, a project
+   ``__init__.py``, or via the ``narractive.tts`` entry-point group).
+
+Quick registration::
+
+    from examples.custom_tts_plugin import SilenceTTSEngine
+    from video_automation.core.narrator import register_tts_engine
+
+    register_tts_engine(SilenceTTSEngine)
+
+config.yaml::
+
+    narration:
+      engine: silence          # matches SilenceTTSEngine.engine_name
+      silence:
+        duration: 1.5          # engine-specific options (optional)
+
+Entry-point registration (for installable packages)
+---------------------------------------------------
+In ``pyproject.toml``::
+
+    [project.entry-points."narractive.tts"]
+    silence = "examples.custom_tts_plugin:SilenceTTSEngine"
+
+Narractive will auto-discover the plugin on startup.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+import wave
+from pathlib import Path
+
+from video_automation.core.tts_base import TTSEngine
+
+logger = logging.getLogger(__name__)
+
+
+class SilenceTTSEngine(TTSEngine):
+    """
+    Minimal TTS engine that writes a silent WAV file.
+
+    Useful for testing the pipeline without a real TTS backend.
+
+    Config options (``narration.silence`` in ``config.yaml``):
+
+    - ``duration`` (float, default 1.0): silence duration in seconds.
+    - ``sample_rate`` (int, default 22050): audio sample rate.
+    """
+
+    engine_name = "silence"
+
+    def generate(self, text: str, output_path: Path, lang: str = "fr", **kwargs) -> Path:
+        """Write a silent WAV file whose length is proportional to *text*."""
+        # Estimate 1 second per 5 words, minimum 0.5 s
+        word_count = max(1, len(text.split()))
+        duration = max(0.5, word_count / 5.0)
+
+        sample_rate = 22050
+        num_samples = int(sample_rate * duration)
+        output_path = output_path.with_suffix(".wav")
+
+        with wave.open(str(output_path), "w") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)  # 16-bit
+            wf.setframerate(sample_rate)
+            # Write silence (all zeros)
+            wf.writeframes(struct.pack("<" + "h" * num_samples, *([0] * num_samples)))
+
+        logger.info(
+            "[SilenceTTS] Generated %.1fs silent WAV: %s", duration, output_path.name
+        )
+        return output_path
+
+    def validate_config(self, config: dict) -> list[str]:
+        errors: list[str] = []
+        duration = config.get("duration", 1.0)
+        if not isinstance(duration, (int, float)) or duration <= 0:
+            errors.append(f"silence.duration must be a positive number, got: {duration!r}")
+        return errors
+
+
+# ---------------------------------------------------------------------------
+# Self-registration when the module is imported directly
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Demo: register and use the engine
+    from video_automation.core.narrator import register_tts_engine
+
+    register_tts_engine(SilenceTTSEngine)
+
+    engine = SilenceTTSEngine()
+    out = engine.generate(
+        "Bonjour, ceci est un test de moteur TTS personnalisé.",
+        Path("/tmp/test_silence.wav"),
+        lang="fr",
+    )
+    print(f"Generated: {out}  ({out.stat().st_size} bytes)")
+    print(f"Duration:  {engine.get_duration(out):.2f}s")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,12 @@ all = [
     "obsws-python>=1.7.0",
     "pywin32>=306",
     "playwright>=1.40",
+    "rich>=13.0",
 ]
 headless = [
     "python-xlib>=0.33",
 ]
+report = ["rich>=13.0"]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -1,0 +1,537 @@
+"""Sprint 5 — Unit tests for:
+  - Issue #12: Pipeline state persistence (resume interrupted runs)
+  - Issue #13: Plugin architecture for custom TTS engines
+  - Issue #14: Production summary / report command
+"""
+from __future__ import annotations
+
+import json
+import struct
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ===========================================================================
+# Issue #12 — Pipeline state persistence
+# ===========================================================================
+
+from video_automation.core.pipeline_state import (
+    PipelineState,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    DEFAULT_STATE_FILE,
+)
+
+
+class TestPipelineStateBasics:
+    def test_default_state_is_empty(self, tmp_path):
+        state = PipelineState(tmp_path / "state.json")
+        assert state._data == {}
+
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        state = PipelineState.load(tmp_path / "nonexistent.json")
+        assert state._data == {}
+
+    def test_start_run_sets_fields(self, tmp_path):
+        state = PipelineState(tmp_path / "state.json")
+        state.start_run(sequences_package="my.pkg", total=5)
+        assert state._data["sequences_package"] == "my.pkg"
+        assert state._data["total"] == 5
+        assert "run_id" in state._data
+
+    def test_save_and_reload(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = PipelineState(path)
+        state.start_run(sequences_package="test.pkg", total=3)
+        state.mark_completed("seq00", recording_path="output/seq00.mkv")
+        state.save()
+
+        loaded = PipelineState.load(path)
+        assert loaded.is_completed("seq00")
+        assert "seq00" in loaded.get_recordings()
+
+    def test_mark_running(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_running("seq01")
+        assert state._data["sequences"]["seq01"]["status"] == STATUS_RUNNING
+
+    def test_mark_failed_with_error(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_failed("seq02", error="TimeoutError: OBS")
+        assert "seq02" in state.failed_ids()
+        assert "TimeoutError" in state._data["sequences"]["seq02"]["error"]
+
+    def test_completed_ids(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00")
+        state.mark_completed("seq02")
+        state.mark_failed("seq01")
+        assert state.completed_ids() == ["seq00", "seq02"]
+
+    def test_failed_ids(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_failed("seq01")
+        assert state.failed_ids() == ["seq01"]
+
+    def test_pending_ids(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00")
+        all_ids = ["seq00", "seq01", "seq02"]
+        pending = state.pending_ids(all_ids)
+        assert pending == ["seq01", "seq02"]
+
+    def test_resume_from_index_skips_completed(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00")
+        state.mark_completed("seq01")
+        all_ids = ["seq00", "seq01", "seq02", "seq03"]
+        assert state.resume_from_index(all_ids) == 2
+
+    def test_resume_from_index_all_done(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        all_ids = ["seq00", "seq01"]
+        for sid in all_ids:
+            state.mark_completed(sid)
+        assert state.resume_from_index(all_ids) == 2
+
+    def test_resume_from_index_empty_state(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        all_ids = ["seq00", "seq01"]
+        assert state.resume_from_index(all_ids) == 0
+
+    def test_delete_removes_file(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = PipelineState(path)
+        state.start_run()
+        state.save()
+        assert path.exists()
+        state.delete()
+        assert not path.exists()
+        assert state._data == {}
+
+    def test_from_config_uses_state_file_key(self, tmp_path):
+        config = {"output": {"state_file": str(tmp_path / "custom.json")}}
+        state = PipelineState.from_config(config)
+        assert state.state_file == tmp_path / "custom.json"
+
+    def test_from_config_default(self, tmp_path):
+        config = {}
+        state = PipelineState.from_config(config)
+        assert str(state.state_file) == DEFAULT_STATE_FILE
+
+    def test_status_table_contains_seq_ids(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00")
+        state.mark_failed("seq01", error="boom")
+        table = state.status_table(["seq00", "seq01", "seq02"])
+        assert "seq00" in table
+        assert "seq01" in table
+        assert "seq02" in table
+
+    def test_to_dict_has_expected_keys(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00")
+        all_ids = ["seq00", "seq01"]
+        d = state.to_dict(all_ids)
+        assert "completed" in d
+        assert "failed" in d
+        assert "pending" in d
+        assert d["completed"] == ["seq00"]
+        assert d["pending"] == ["seq01"]
+
+    def test_corrupted_state_file_ignored(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not valid json", encoding="utf-8")
+        state = PipelineState.load(path)
+        assert state._data == {}
+
+    def test_recordings_stored(self, tmp_path):
+        state = PipelineState(tmp_path / "s.json")
+        state.start_run()
+        state.mark_completed("seq00", recording_path="/out/seq00.mkv")
+        recs = state.get_recordings()
+        assert recs["seq00"] == "/out/seq00.mkv"
+
+
+# ===========================================================================
+# Issue #13 — Plugin architecture for custom TTS engines
+# ===========================================================================
+
+from video_automation.core.tts_base import (
+    TTSEngine,
+    register_tts_engine,
+    get_tts_engine,
+    list_registered_engines,
+    _REGISTRY,
+)
+
+
+class _MockEngine(TTSEngine):
+    engine_name = "mock-test-engine-sprint5"
+
+    def generate(self, text: str, output_path: Path, lang: str = "fr", **kwargs) -> Path:
+        output_path.write_bytes(b"fake-audio")
+        return output_path
+
+
+class TestTTSEngineRegistry:
+    def setup_method(self):
+        # Remove our test engine before each test to keep tests isolated
+        _REGISTRY.pop("mock-test-engine-sprint5", None)
+
+    def teardown_method(self):
+        _REGISTRY.pop("mock-test-engine-sprint5", None)
+
+    def test_register_and_retrieve(self):
+        register_tts_engine(_MockEngine)
+        assert get_tts_engine("mock-test-engine-sprint5") is _MockEngine
+
+    def test_list_includes_registered(self):
+        register_tts_engine(_MockEngine)
+        assert "mock-test-engine-sprint5" in list_registered_engines()
+
+    def test_unregistered_engine_returns_none(self):
+        assert get_tts_engine("totally-unknown-xyz") is None
+
+    def test_register_without_engine_name_raises(self):
+        class BadEngine(TTSEngine):
+            engine_name = ""
+
+            def generate(self, text, output_path, lang="fr", **kwargs):
+                return output_path
+
+        with pytest.raises(ValueError, match="engine_name"):
+            register_tts_engine(BadEngine)
+
+    def test_generate_writes_file(self, tmp_path):
+        register_tts_engine(_MockEngine)
+        engine = _MockEngine()
+        out = tmp_path / "test.mp3"
+        result = engine.generate("Hello world", out, lang="en")
+        assert result.exists()
+        assert result.read_bytes() == b"fake-audio"
+
+    def test_validate_config_default_returns_empty(self):
+        register_tts_engine(_MockEngine)
+        engine = _MockEngine()
+        errors = engine.validate_config({})
+        assert errors == []
+
+    def test_get_duration_fallback(self, tmp_path):
+        """get_duration returns 0.0 when mutagen is unavailable and file is not audio."""
+        engine = _MockEngine()
+        fake_path = tmp_path / "fake.mp3"
+        fake_path.write_bytes(b"not audio")
+        dur = engine.get_duration(fake_path)
+        assert isinstance(dur, float)
+
+
+class TestSilencePluginExample:
+    """Test the example custom TTS plugin."""
+
+    def test_silence_engine_generates_wav(self, tmp_path):
+        from examples.custom_tts_plugin import SilenceTTSEngine
+
+        engine = SilenceTTSEngine()
+        out = tmp_path / "silence.wav"
+        result = engine.generate("Hello world test sentence.", out)
+        assert result.exists()
+        assert result.suffix == ".wav"
+
+    def test_silence_engine_name(self):
+        from examples.custom_tts_plugin import SilenceTTSEngine
+
+        assert SilenceTTSEngine.engine_name == "silence"
+
+    def test_silence_engine_validate_config(self):
+        from examples.custom_tts_plugin import SilenceTTSEngine
+
+        engine = SilenceTTSEngine()
+        assert engine.validate_config({"duration": 1.5}) == []
+        errors = engine.validate_config({"duration": -1})
+        assert len(errors) > 0
+
+    def test_silence_wav_is_valid(self, tmp_path):
+        from examples.custom_tts_plugin import SilenceTTSEngine
+
+        engine = SilenceTTSEngine()
+        out = tmp_path / "check.wav"
+        result = engine.generate("Five words for test.", out)
+
+        with wave.open(str(result), "r") as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getnframes() > 0
+
+
+class TestNarratorPluginIntegration:
+    """Test that Narrator correctly dispatches to registered plugins."""
+
+    def setup_method(self):
+        _REGISTRY.pop("mock-test-engine-sprint5", None)
+
+    def teardown_method(self):
+        _REGISTRY.pop("mock-test-engine-sprint5", None)
+
+    def test_narrator_uses_registered_plugin(self, tmp_path):
+        from video_automation.core.narrator import Narrator
+
+        register_tts_engine(_MockEngine)
+        narrator = Narrator({"engine": "mock-test-engine-sprint5",
+                              "output_dir": str(tmp_path)})
+        out = tmp_path / "seq00_narration.mp3"
+        result = narrator.generate_narration("Test narration.", out)
+        assert result.exists()
+
+    def test_narrator_raises_for_unknown_engine(self, tmp_path):
+        from video_automation.core.narrator import Narrator
+
+        narrator = Narrator({"engine": "totally-unknown-xyz-engine",
+                              "output_dir": str(tmp_path)})
+        with pytest.raises(ValueError, match="Unknown TTS engine"):
+            narrator.generate_narration("test", tmp_path / "out.mp3")
+
+    def test_register_tts_engine_importable_from_narrator(self):
+        from video_automation.core.narrator import register_tts_engine as rte
+        assert callable(rte)
+
+
+# ===========================================================================
+# Issue #14 — Production summary / report command
+# ===========================================================================
+
+from video_automation.core.report import (
+    ProductionReport,
+    SequenceEntry,
+    _fmt_duration,
+    _fmt_size,
+)
+
+
+class TestFormatHelpers:
+    def test_fmt_duration_seconds(self):
+        assert _fmt_duration(45.0) == "45s"
+
+    def test_fmt_duration_minutes(self):
+        assert _fmt_duration(90.0) == "1m 30s"
+
+    def test_fmt_duration_zero(self):
+        assert _fmt_duration(0.0) == "0s"
+
+    def test_fmt_size_bytes(self):
+        assert "B" in _fmt_size(512)
+
+    def test_fmt_size_megabytes(self):
+        result = _fmt_size(5 * 1024 * 1024)
+        assert "MB" in result
+
+    def test_fmt_size_zero(self):
+        assert _fmt_size(0) == "0 B"
+
+
+class TestSequenceEntry:
+    def test_to_dict_keys(self):
+        entry = SequenceEntry("seq00")
+        d = entry.to_dict()
+        assert "seq_id" in d
+        assert "clip_duration" in d
+        assert "narration_duration" in d
+        assert "subtitles" in d
+
+    def test_to_dict_with_paths(self, tmp_path):
+        entry = SequenceEntry("seq01")
+        entry.clip_path = tmp_path / "seq01.mkv"
+        entry.clip_duration = 30.5
+        d = entry.to_dict()
+        assert d["clip_duration"] == 30.5
+        assert "seq01.mkv" in d["clip"]
+
+
+class TestProductionReport:
+    def _make_config(self, tmp_path):
+        return {
+            "output": {
+                "final_dir": str(tmp_path / "final"),
+                "clips_dir": str(tmp_path / "obs"),
+                "state_file": str(tmp_path / ".narractive-state.json"),
+            },
+            "narration": {
+                "engine": "edge-tts",
+                "output_dir": str(tmp_path / "narration"),
+            },
+            "subtitles": {
+                "output_dir": str(tmp_path / "{lang}" / "subtitles"),
+            },
+            "languages": {"fr": {}, "en": {}},
+        }
+
+    def _write_wav(self, path: Path, duration_frames: int = 4410) -> None:
+        """Write a minimal valid WAV file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with wave.open(str(path), "w") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(22050)
+            wf.writeframes(struct.pack("<" + "h" * duration_frames, *([0] * duration_frames)))
+
+    def test_collect_with_narration_files(self, tmp_path):
+        config = self._make_config(tmp_path)
+        narr_dir = tmp_path / "narration"
+        narr_dir.mkdir(parents=True)
+        self._write_wav(narr_dir / "seq00_narration.wav")
+        self._write_wav(narr_dir / "seq01_narration.wav")
+
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect(project_name="Test")
+
+        assert len(rpt.sequences) >= 2
+        seq_ids = [e.seq_id for e in rpt.sequences]
+        assert "seq00" in seq_ids
+        assert "seq01" in seq_ids
+
+    def test_collect_detects_subtitles(self, tmp_path):
+        config = self._make_config(tmp_path)
+        narr_dir = tmp_path / "narration"
+        narr_dir.mkdir(parents=True)
+        self._write_wav(narr_dir / "seq00_narration.wav")
+
+        srt_dir = tmp_path / "fr" / "subtitles"
+        srt_dir.mkdir(parents=True)
+        (srt_dir / "seq00.srt").write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
+
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect(project_name="Test")
+
+        assert len(rpt.sequences) > 0
+        seq = rpt.sequences[0]
+        assert "fr" in seq.subtitles
+
+    def test_to_dict_structure(self, tmp_path):
+        config = self._make_config(tmp_path)
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect(project_name="Test")
+        d = rpt.to_dict()
+
+        assert "generated_at" in d
+        assert "tts_engine" in d
+        assert "sequences" in d
+        assert "total_clip_duration" in d
+        assert "total_narration_duration" in d
+
+    def test_print_ascii_no_crash(self, tmp_path):
+        config = self._make_config(tmp_path)
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect(project_name="Test")
+        # Should not raise even with empty output dirs
+        rpt._print_ascii()
+
+    def test_json_serialisable(self, tmp_path):
+        config = self._make_config(tmp_path)
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect(project_name="Test")
+        # Must not raise
+        serialized = json.dumps(rpt.to_dict())
+        assert len(serialized) > 0
+
+    def test_empty_output_dir_no_crash(self, tmp_path):
+        config = self._make_config(tmp_path)
+        rpt = ProductionReport(config, build_dir=tmp_path)
+        rpt.collect()
+        assert rpt.sequences == []
+
+
+# ===========================================================================
+# CLI integration tests (smoke tests using Click test runner)
+# ===========================================================================
+
+from click.testing import CliRunner
+from video_automation.cli import cli
+
+
+class TestCLIStatus:
+    def test_status_no_config(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["--status"])
+            # Should fail gracefully (no config.yaml), not crash with exception
+            assert result.exit_code != 0 or "state" in result.output.lower()
+
+
+class TestCLIReport:
+    def _make_config_file(self, tmp_path):
+        cfg = {
+            "output": {"final_dir": str(tmp_path / "final")},
+            "narration": {"engine": "edge-tts", "output_dir": str(tmp_path / "narration")},
+        }
+        import yaml  # type: ignore
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump(cfg), encoding="utf-8")
+        return config_path
+
+    def test_report_command_json_flag(self, tmp_path):
+        try:
+            import yaml  # noqa
+        except ImportError:
+            pytest.skip("pyyaml not installed")
+
+        runner = CliRunner()
+        config_path = self._make_config_file(tmp_path)
+        result = runner.invoke(
+            cli,
+            ["report", str(tmp_path), "--config", str(config_path), "--json"],
+        )
+        # Should produce valid JSON output
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "sequences" in data
+        assert "tts_engine" in data
+
+    def test_report_command_ascii(self, tmp_path):
+        try:
+            import yaml  # noqa
+        except ImportError:
+            pytest.skip("pyyaml not installed")
+
+        runner = CliRunner()
+        config_path = self._make_config_file(tmp_path)
+        result = runner.invoke(
+            cli,
+            ["report", str(tmp_path), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_report_output_json_file(self, tmp_path):
+        try:
+            import yaml  # noqa
+        except ImportError:
+            pytest.skip("pyyaml not installed")
+
+        runner = CliRunner()
+        config_path = self._make_config_file(tmp_path)
+        out_file = tmp_path / "report.json"
+        result = runner.invoke(
+            cli,
+            [
+                "report", str(tmp_path),
+                "--config", str(config_path),
+                "--output", str(out_file),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        data = json.loads(out_file.read_text())
+        assert "sequences" in data

--- a/video_automation/cli.py
+++ b/video_automation/cli.py
@@ -129,6 +129,12 @@ def load_sequences_from_package(package_path: str) -> list:
               help="Run only sequence N")
 @click.option("--from", "start_from", type=int, default=None, metavar="N",
               help="Resume pipeline from sequence N")
+@click.option("--resume", "resume", is_flag=True,
+              help="Automatically resume from the last failed/interrupted sequence (uses pipeline state)")
+@click.option("--reset", "reset_state", is_flag=True,
+              help="Delete pipeline state file and start fresh")
+@click.option("--status", "show_status", is_flag=True,
+              help="Show current pipeline state (completed/failed/pending sequences)")
 @click.option("--diagrams", is_flag=True, help="Generate Mermaid diagram HTML/PNG files")
 @click.option("--diagrams-module", type=str, default=None, metavar="MOD",
               help="Python module path for diagram definitions (e.g. 'examples.filtermate.diagrams.mermaid_definitions')")
@@ -157,7 +163,8 @@ def load_sequences_from_package(package_path: str) -> list:
 @click.option("--project-name", type=str, default="Video", help="Project name for output labeling")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose (DEBUG) logging")
 @click.pass_context
-def cli(ctx, config, seq_pkg, run_all, sequence, start_from, diagrams, diagrams_module,
+def cli(ctx, config, seq_pkg, run_all, sequence, start_from, resume, reset_state, show_status,
+        diagrams, diagrams_module,
         narration, force_narration, narrations_file, video, calibrate, setup_obs, subtitles, lang,
         narrations_dir, quality, assemble, capture, capture_fps, dry_run, list_seqs,
         project_name, verbose):
@@ -165,8 +172,8 @@ def cli(ctx, config, seq_pkg, run_all, sequence, start_from, diagrams, diagrams_
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    # Subcommands that don't need a pre-existing config.yaml
-    if ctx.invoked_subcommand in ("init", "validate-config"):
+    # Subcommands that manage their own config loading
+    if ctx.invoked_subcommand in ("init", "validate-config", "preview", "report"):
         return
 
     # Find config
@@ -196,6 +203,20 @@ def cli(ctx, config, seq_pkg, run_all, sequence, start_from, diagrams, diagrams_
     ctx.obj["quality"] = quality
 
     # Dispatch
+    if reset_state:
+        from video_automation.core.pipeline_state import PipelineState
+        state = PipelineState.from_config(cfg)
+        state.delete()
+        click.echo("Pipeline state reset.")
+        if not run_all:
+            return
+
+    if show_status:
+        from video_automation.core.pipeline_state import PipelineState
+        state = PipelineState.from_config(cfg)
+        click.echo(state.status_table())
+        return
+
     if list_seqs:
         cmd_list(cfg, seq_pkg=seq_pkg, project_name=project_name)
         return
@@ -231,7 +252,8 @@ def cli(ctx, config, seq_pkg, run_all, sequence, start_from, diagrams, diagrams_
 
     if run_all:
         cmd_run_all(cfg, dry_run, seq_pkg=seq_pkg, use_capture=capture,
-                    start_from=start_from, project_name=project_name, video=video)
+                    start_from=start_from, project_name=project_name, video=video,
+                    resume=resume)
         return
 
     click.echo(ctx.get_help())
@@ -443,8 +465,11 @@ def cmd_run_all(
     seq_pkg: str | None = None, use_capture: bool = False,
     start_from: int | None = None, project_name: str = "Video",
     video: str | None = None,
+    resume: bool = False,
 ) -> None:
     """Run the complete video production pipeline."""
+    from video_automation.core.pipeline_state import PipelineState
+
     SEQUENCES = _load_sequences(seq_pkg)
     backend = "FrameCapture" if use_capture else "OBS"
 
@@ -452,16 +477,42 @@ def cmd_run_all(
     click.echo(f"  {project_name} — Complete Video Production ({backend})")
     click.echo("=" * 65)
 
-    if start_from is not None:
+    # Build ordered list of sequence IDs for state tracking
+    seq_instances = [SeqClass() for SeqClass in SEQUENCES]
+    all_seq_ids = [
+        getattr(seq, "sequence_id", f"seq{i:02d}")
+        for i, seq in enumerate(seq_instances)
+    ]
+
+    # Load / initialise pipeline state
+    state = PipelineState.from_config(config)
+
+    # Determine effective start index
+    if resume:
+        effective_start = state.resume_from_index(all_seq_ids)
+        if effective_start > 0:
+            click.echo(
+                f"\n  Resuming from sequence {effective_start} "
+                f"({all_seq_ids[effective_start] if effective_start < len(all_seq_ids) else 'end'})"
+                f" — {len(state.completed_ids())} already completed."
+            )
+    elif start_from is not None:
         if start_from < 0 or start_from >= len(SEQUENCES):
             click.echo(f"Error: --from {start_from} out of range (0-{len(SEQUENCES) - 1})")
             sys.exit(1)
+        effective_start = start_from
+    else:
+        effective_start = 0
+
+    if not resume:
+        # Fresh run: reinitialise state (keeps existing entries on partial --from)
+        state.start_run(sequences_package=seq_pkg or "", total=len(SEQUENCES))
+        state.save()
 
     if dry_run:
         click.echo(f"\n[DRY-RUN] Would run these sequences (backend: {backend}):\n")
-        for i, SeqClass in enumerate(SEQUENCES):
-            seq = SeqClass()
-            skipped = start_from is not None and i < start_from
+        for i, seq in enumerate(seq_instances):
+            skipped = i < effective_start
             marker = "SKIP" if skipped else " RUN"
             click.echo(f"  [{marker}] [{i}] {seq.name:<40} {seq.duration_estimate:.0f}s")
         return
@@ -475,14 +526,27 @@ def cmd_run_all(
 
     with recorder:
         for i, SeqClass in enumerate(SEQUENCES):
-            if start_from is not None and i < start_from:
+            if i < effective_start:
                 continue
 
-            seq = SeqClass()
+            seq = seq_instances[i]
+            seq_id = all_seq_ids[i]
+
+            # Skip already-completed sequences when resuming
+            if resume and state.is_completed(seq_id):
+                click.echo(f"\n  [SKIP] [{i}/{len(SEQUENCES)-1}] {seq.name} (already completed)")
+                recorded = state.get_recordings().get(seq_id)
+                if recorded:
+                    recording_files.append(recorded)
+                continue
+
             click.echo(f"\n[{i}/{len(SEQUENCES)-1}] {seq.name}")
+            state.mark_running(seq_id)
+            state.save()
 
             recorder.start_recording()
             recorder.wait_for_recording_start()
+            output_path = None
             try:
                 seq.run(recorder, app, config)
             except KeyboardInterrupt:
@@ -491,18 +555,35 @@ def cmd_run_all(
                 if output_path:
                     recording_files.append(output_path)
                     all_timeline_results.append((output_path, seq.timeline_result))
+                    state.mark_completed(seq_id, recording_path=output_path)
+                    state.save()
                 break
             except Exception as exc:
                 logger.error("Sequence %d failed: %s", i, exc)
                 click.echo(f"  x Sequence {i} failed: {exc}")
-            finally:
                 output_path = recorder.stop_recording()
+                state.mark_failed(seq_id, error=str(exc))
+                state.save()
                 if output_path:
+                    recording_files.append(output_path)
+                    all_timeline_results.append((output_path, seq.timeline_result))
+                time.sleep(3)
+                continue
+            finally:
+                if output_path is None:
+                    output_path = recorder.stop_recording()
+                if output_path and output_path not in recording_files:
                     recording_files.append(output_path)
                     click.echo(f"  ok Saved: {output_path}")
                     all_timeline_results.append((output_path, seq.timeline_result))
                     if seq.timeline_result:
-                        click.echo(f"       Timeline: {len(seq.timeline_result.narration_timecodes)} narration segments")
+                        click.echo(
+                            f"       Timeline: "
+                            f"{len(seq.timeline_result.narration_timecodes)} narration segments"
+                        )
+                    if not state.is_completed(seq_id):
+                        state.mark_completed(seq_id, recording_path=output_path)
+                        state.save()
                 time.sleep(3)
 
     click.echo(f"\nRecorded {len(recording_files)} clips.")
@@ -834,3 +915,85 @@ def _play_audio(audio_path: Path) -> None:
             click.echo("  (install ffplay or playsound to play audio)")
     except Exception as exc:
         click.echo(f"  !! Playback error: {exc}")
+
+
+# ── `narractive report` ───────────────────────────────────────────────────
+
+
+@cli.command("report")
+@click.argument("build_dir", default="output", type=click.Path())
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default="config.yaml",
+    show_default=True,
+    help="Path to config.yaml.",
+)
+@click.option(
+    "--project-name",
+    "project_name",
+    type=str,
+    default=None,
+    help="Project display name (defaults to build_dir name).",
+)
+@click.option(
+    "--video",
+    "video",
+    type=str,
+    default=None,
+    metavar="VXX",
+    help="Video script key (e.g. 'v01') for locating narration sub-directories.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    metavar="FILE",
+    help="Write machine-readable JSON report to FILE (e.g. report.json).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Print JSON report to stdout.")
+def cmd_report(
+    build_dir: str,
+    config_path: str,
+    project_name: str | None,
+    video: str | None,
+    output_path: str | None,
+    as_json: bool,
+) -> None:
+    """Show a production summary for BUILD_DIR (default: output/).
+
+    Scans clips, narration audio, subtitle files, and the final assembled
+    video to report durations, sizes, and per-language subtitle coverage.
+
+    Examples::
+
+        narractive report
+        narractive report output/ --project-name "My Demo" --video v01
+        narractive report --json
+        narractive report --output report.json
+    """
+    import json as _json
+
+    from video_automation.core.report import ProductionReport
+
+    cfg = load_config(Path(config_path))
+    build_path = Path(build_dir).resolve()
+    pname = project_name or build_path.name or "Production"
+
+    rpt = ProductionReport(cfg, build_dir=build_path)
+    rpt.collect(project_name=pname, video=video)
+
+    if as_json:
+        click.echo(_json.dumps(rpt.to_dict(), indent=2, ensure_ascii=False))
+        return
+
+    rpt.print_table()
+
+    if output_path:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as f:
+            _json.dump(rpt.to_dict(), f, indent=2, ensure_ascii=False)
+        click.echo(f"  JSON report written to {out}")

--- a/video_automation/core/narrator.py
+++ b/video_automation/core/narrator.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import Optional
 
 from video_automation.core.text_preprocessor import TextPreprocessor
+# Re-export for convenience: `from video_automation.core.narrator import register_tts_engine`
+from video_automation.core.tts_base import register_tts_engine as register_tts_engine  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -539,10 +541,15 @@ class Narrator:
         elif self.engine == "openai":
             result = self._generate_openai(text, output_path)
         else:
-            raise ValueError(
-                f"Unknown TTS engine: {self.engine}. "
-                "Use 'edge-tts', 'elevenlabs', 'f5-tts', 'xtts-v2', 'kokoro', or 'openai'."
-            )
+            # Try the plugin registry before giving up
+            result = self._generate_plugin(text, output_path, lang=lang)
+            if result is None:
+                raise ValueError(
+                    f"Unknown TTS engine: {self.engine!r}. "
+                    "Built-in engines: edge-tts, elevenlabs, f5-tts, xtts-v2, kokoro, openai. "
+                    "Register a custom engine with register_tts_engine() or via the "
+                    "'narractive.tts' entry-point group."
+                )
 
         # Post-process: EBU R128 loudness normalization (opt-in)
         if self.normalize_loudness:
@@ -1002,6 +1009,28 @@ class Narrator:
             out_path.name, self.get_narration_duration(out_path),
         )
         return out_path
+
+    def _generate_plugin(
+        self, text: str, output_path: Path, lang: str = "fr"
+    ) -> "Path | None":
+        """
+        Attempt to generate audio using a registered :class:`~video_automation.core.tts_base.TTSEngine` plugin.
+
+        Returns the output :class:`Path` on success, or ``None`` when no plugin
+        is registered for ``self.engine``.
+        """
+        from video_automation.core.tts_base import get_tts_engine, load_entry_point_plugins
+
+        # Ensure entry-point plugins are loaded (idempotent)
+        load_entry_point_plugins()
+
+        engine_cls = get_tts_engine(self.engine)
+        if engine_cls is None:
+            return None
+
+        engine_instance = engine_cls()
+        logger.info("Using plugin TTS engine '%s': %s", self.engine, engine_cls.__name__)
+        return engine_instance.generate(text, output_path, lang=lang)
 
     @staticmethod
     def _wav_to_mp3(wav_path: Path, mp3_path: Path) -> None:

--- a/video_automation/core/pipeline_state.py
+++ b/video_automation/core/pipeline_state.py
@@ -1,0 +1,341 @@
+"""
+Pipeline State — Persistent Run State for Resume Support
+=========================================================
+Tracks which sequences have completed, failed, or are pending in a JSON
+sidecar file so an interrupted ``narractive --all`` run can be resumed
+automatically with ``narractive --all --resume``.
+
+State file location: ``output/.narractive-state.json`` (configurable).
+
+Usage::
+
+    from video_automation.core.pipeline_state import PipelineState
+
+    state = PipelineState.load("output/.narractive-state.json")
+    state.start_run(sequences_package="my_project.sequences", total=11)
+
+    state.mark_completed("seq00", recording_path="output/obs/seq00.mkv")
+    state.mark_failed("seq01", error="TimeoutError: OBS did not respond")
+    state.save()
+
+    # On next invocation with --resume:
+    state = PipelineState.load("output/.narractive-state.json")
+    resume_from = state.resume_from_index()   # index of first non-completed seq
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Default state file relative to the working directory
+DEFAULT_STATE_FILE = "output/.narractive-state.json"
+
+# Sequence status constants
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+
+
+class PipelineState:
+    """
+    Persists and queries the execution state of a pipeline run.
+
+    Parameters
+    ----------
+    state_file : Path
+        Path to the JSON state file.
+    """
+
+    def __init__(self, state_file: Path) -> None:
+        self.state_file = Path(state_file)
+        self._data: dict = {}
+
+    # ------------------------------------------------------------------
+    # Factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def load(cls, state_file: str | Path = DEFAULT_STATE_FILE) -> "PipelineState":
+        """
+        Load state from *state_file*, or return a blank state if it does not exist.
+
+        Parameters
+        ----------
+        state_file : str | Path
+            Path to the JSON state file.
+        """
+        path = Path(state_file)
+        instance = cls(path)
+
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as f:
+                    instance._data = json.load(f)
+                logger.info("Pipeline state loaded from %s", path)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Could not read pipeline state (%s): %s — starting fresh", path, exc)
+                instance._data = {}
+        else:
+            logger.debug("No pipeline state file found at %s — starting fresh", path)
+
+        return instance
+
+    @classmethod
+    def from_config(cls, config: dict) -> "PipelineState":
+        """
+        Create a :class:`PipelineState` using the ``output.state_file`` config key.
+
+        Falls back to :data:`DEFAULT_STATE_FILE` when the key is absent.
+        """
+        state_file = config.get("output", {}).get("state_file", DEFAULT_STATE_FILE)
+        return cls.load(state_file)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self) -> None:
+        """Write the current state to disk."""
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, indent=2, ensure_ascii=False)
+            logger.debug("Pipeline state saved to %s", self.state_file)
+        except OSError as exc:
+            logger.warning("Failed to save pipeline state: %s", exc)
+
+    def delete(self) -> None:
+        """Delete the state file (--reset behaviour)."""
+        if self.state_file.exists():
+            self.state_file.unlink()
+            logger.info("Pipeline state deleted: %s", self.state_file)
+        self._data = {}
+
+    # ------------------------------------------------------------------
+    # Run lifecycle
+    # ------------------------------------------------------------------
+
+    def start_run(
+        self,
+        sequences_package: Optional[str] = None,
+        total: int = 0,
+    ) -> None:
+        """
+        Initialise state for a new pipeline run.
+
+        Parameters
+        ----------
+        sequences_package : str | None
+            Dotted package path for the sequences being run.
+        total : int
+            Total number of sequences in the run.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        self._data = {
+            "run_id": now,
+            "sequences_package": sequences_package or "",
+            "total": total,
+            "started_at": now,
+            "updated_at": now,
+            "sequences": {},
+            "recordings": {},
+        }
+
+    def _ensure_run(self) -> None:
+        if not self._data:
+            self.start_run()
+
+    # ------------------------------------------------------------------
+    # Sequence status tracking
+    # ------------------------------------------------------------------
+
+    def mark_running(self, seq_id: str) -> None:
+        """Mark *seq_id* as currently running."""
+        self._ensure_run()
+        self._data["sequences"][seq_id] = {
+            "status": STATUS_RUNNING,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    def mark_completed(self, seq_id: str, recording_path: Optional[str] = None) -> None:
+        """
+        Mark *seq_id* as successfully completed.
+
+        Parameters
+        ----------
+        seq_id : str
+            Sequence identifier (e.g. ``"seq00"``).
+        recording_path : str | None
+            Path to the recorded video clip, if any.
+        """
+        self._ensure_run()
+        entry: dict = {
+            "status": STATUS_COMPLETED,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if recording_path:
+            entry["recording"] = str(recording_path)
+            self._data["recordings"][seq_id] = str(recording_path)
+        self._data["sequences"][seq_id] = entry
+        self._data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    def mark_failed(self, seq_id: str, error: Optional[str] = None) -> None:
+        """
+        Mark *seq_id* as failed.
+
+        Parameters
+        ----------
+        seq_id : str
+            Sequence identifier.
+        error : str | None
+            Short description of the error, for display in ``narractive --status``.
+        """
+        self._ensure_run()
+        entry: dict = {
+            "status": STATUS_FAILED,
+            "failed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if error:
+            entry["error"] = str(error)[:512]
+        self._data["sequences"][seq_id] = entry
+        self._data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def is_completed(self, seq_id: str) -> bool:
+        """Return ``True`` if *seq_id* completed successfully."""
+        return self._data.get("sequences", {}).get(seq_id, {}).get("status") == STATUS_COMPLETED
+
+    def completed_ids(self) -> list[str]:
+        """Return a sorted list of completed sequence IDs."""
+        return sorted(
+            sid
+            for sid, info in self._data.get("sequences", {}).items()
+            if info.get("status") == STATUS_COMPLETED
+        )
+
+    def failed_ids(self) -> list[str]:
+        """Return a sorted list of failed sequence IDs."""
+        return sorted(
+            sid
+            for sid, info in self._data.get("sequences", {}).items()
+            if info.get("status") == STATUS_FAILED
+        )
+
+    def pending_ids(self, all_seq_ids: list[str]) -> list[str]:
+        """
+        Return sequence IDs from *all_seq_ids* that are not yet completed.
+
+        Parameters
+        ----------
+        all_seq_ids : list[str]
+            Ordered list of all sequence IDs in the pipeline.
+        """
+        completed = set(self.completed_ids())
+        return [sid for sid in all_seq_ids if sid not in completed]
+
+    def resume_from_index(self, all_seq_ids: list[str]) -> int:
+        """
+        Return the index in *all_seq_ids* from which to resume.
+
+        This is the index of the first sequence that is **not** completed.
+        Returns ``0`` when there is no existing state (fresh start).
+
+        Parameters
+        ----------
+        all_seq_ids : list[str]
+            Ordered list of all sequence IDs (matching the run order).
+        """
+        completed = set(self.completed_ids())
+        for i, sid in enumerate(all_seq_ids):
+            if sid not in completed:
+                return i
+        return len(all_seq_ids)  # all done
+
+    def get_recordings(self) -> dict[str, str]:
+        """Return the ``{seq_id: recording_path}`` mapping."""
+        return dict(self._data.get("recordings", {}))
+
+    # ------------------------------------------------------------------
+    # Pretty display
+    # ------------------------------------------------------------------
+
+    def status_table(self, all_seq_ids: Optional[list[str]] = None) -> str:
+        """
+        Return a human-readable status table.
+
+        Parameters
+        ----------
+        all_seq_ids : list[str] | None
+            Ordered list of all sequence IDs.  When ``None``, only the
+            sequences recorded in state are shown.
+        """
+        seqs = self._data.get("sequences", {})
+        if all_seq_ids is None:
+            all_seq_ids = sorted(seqs.keys())
+
+        if not all_seq_ids:
+            return "(no pipeline state found)"
+
+        icon = {
+            STATUS_COMPLETED: "ok",
+            STATUS_FAILED: "FAIL",
+            STATUS_RUNNING: "...",
+            STATUS_PENDING: "    ",
+        }
+
+        run_id = self._data.get("run_id", "unknown")
+        pkg = self._data.get("sequences_package", "")
+        lines = [
+            f"Pipeline State — run {run_id}",
+            f"Package: {pkg}" if pkg else "",
+            "-" * 50,
+            f"  {'Status':<8}  {'Sequence ID':<20}  {'Info'}",
+            "-" * 50,
+        ]
+
+        for sid in all_seq_ids:
+            info = seqs.get(sid, {})
+            status = info.get("status", STATUS_PENDING)
+            mark = icon.get(status, "?")
+            extra = ""
+            if status == STATUS_FAILED:
+                extra = f"  ERROR: {info.get('error', '')}"
+            elif status == STATUS_COMPLETED and "recording" in info:
+                extra = f"  -> {Path(info['recording']).name}"
+            lines.append(f"  [{mark:<4}]  {sid:<20}  {extra}")
+
+        completed = len(self.completed_ids())
+        failed = len(self.failed_ids())
+        total = len(all_seq_ids)
+        lines += [
+            "-" * 50,
+            f"  {completed}/{total} completed, {failed} failed",
+        ]
+        return "\n".join(l for l in lines if l != "")
+
+    # ------------------------------------------------------------------
+    # Serialization (for --json output)
+    # ------------------------------------------------------------------
+
+    def to_dict(self, all_seq_ids: Optional[list[str]] = None) -> dict:
+        """Return the state as a plain dict (suitable for JSON serialisation)."""
+        seqs = self._data.get("sequences", {})
+        if all_seq_ids is None:
+            all_seq_ids = list(seqs.keys())
+
+        result = dict(self._data)
+        result["completed"] = self.completed_ids()
+        result["failed"] = self.failed_ids()
+        result["pending"] = self.pending_ids(all_seq_ids)
+        return result

--- a/video_automation/core/report.py
+++ b/video_automation/core/report.py
@@ -1,0 +1,469 @@
+"""
+Production Report — Build Summary for Narractive
+==================================================
+Scans an output directory and generates a structured report of the
+production artefacts: clip durations, narration lengths, subtitle coverage,
+final video metadata, and total sizes.
+
+Used by the ``narractive report [build_dir]`` CLI command.
+
+Usage::
+
+    from video_automation.core.report import ProductionReport
+
+    rpt = ProductionReport(config, build_dir=Path("output"))
+    rpt.collect()
+    rpt.print_table()               # Rich table or ASCII fallback
+    data = rpt.to_dict()            # Machine-readable dict
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _ffprobe_file(path: Path) -> dict:
+    """
+    Run ``ffprobe`` on *path* and return a metadata dict.
+
+    Keys: ``duration`` (float, s), ``size`` (int, bytes),
+          ``width`` (int), ``height`` (int), ``codec_video`` (str),
+          ``codec_audio`` (str).
+    Returns an empty dict when ffprobe is unavailable or fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "quiet",
+                "-print_format", "json",
+                "-show_streams", "-show_format",
+                str(path),
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return {}
+        data = json.loads(result.stdout)
+        fmt = data.get("format", {})
+        streams = data.get("streams", [])
+
+        video_stream = next((s for s in streams if s.get("codec_type") == "video"), {})
+        audio_stream = next((s for s in streams if s.get("codec_type") == "audio"), {})
+
+        return {
+            "duration": float(fmt.get("duration", 0)),
+            "size": int(fmt.get("size", 0)),
+            "width": int(video_stream.get("width", 0)),
+            "height": int(video_stream.get("height", 0)),
+            "codec_video": video_stream.get("codec_name", ""),
+            "codec_audio": audio_stream.get("codec_name", ""),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("ffprobe failed on %s: %s", path, exc)
+        return {}
+
+
+def _mutagen_duration(path: Path) -> float:
+    """Return audio duration in seconds via mutagen, or 0.0 on failure."""
+    try:
+        from mutagen import File as MutagenFile  # type: ignore
+
+        audio = MutagenFile(str(path))
+        if audio is not None and audio.info is not None:
+            return float(audio.info.length)
+    except Exception:  # noqa: BLE001
+        pass
+    return _ffprobe_file(path).get("duration", 0.0)
+
+
+def _fmt_size(size_bytes: int) -> str:
+    """Format bytes as human-readable string."""
+    if size_bytes <= 0:
+        return "0 B"
+    for unit in ("B", "KB", "MB", "GB"):
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024  # type: ignore[assignment]
+    return f"{size_bytes:.1f} TB"
+
+
+def _fmt_duration(secs: float) -> str:
+    """Format seconds as ``Xm Ys``."""
+    secs = max(0.0, secs)
+    m, s = divmod(int(secs), 60)
+    if m:
+        return f"{m}m {s:02d}s"
+    return f"{s}s"
+
+
+# ---------------------------------------------------------------------------
+# Sequence entry
+# ---------------------------------------------------------------------------
+
+
+class SequenceEntry:
+    """Metadata for a single sequence in the production."""
+
+    def __init__(self, seq_id: str) -> None:
+        self.seq_id = seq_id
+        self.clip_path: Optional[Path] = None
+        self.clip_duration: float = 0.0
+        self.narration_path: Optional[Path] = None
+        self.narration_duration: float = 0.0
+        self.subtitles: dict[str, Path] = {}  # lang -> .srt path
+
+    def to_dict(self) -> dict:
+        return {
+            "seq_id": self.seq_id,
+            "clip": str(self.clip_path) if self.clip_path else None,
+            "clip_duration": round(self.clip_duration, 2),
+            "narration": str(self.narration_path) if self.narration_path else None,
+            "narration_duration": round(self.narration_duration, 2),
+            "subtitles": {lang: str(p) for lang, p in self.subtitles.items()},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Main report class
+# ---------------------------------------------------------------------------
+
+
+class ProductionReport:
+    """
+    Gathers and formats a production summary.
+
+    Parameters
+    ----------
+    config : dict
+        The full narractive config dict.
+    build_dir : Path | None
+        Root output directory.  Defaults to ``output/`` relative to cwd.
+    """
+
+    def __init__(self, config: dict, build_dir: Optional[Path] = None) -> None:
+        self.config = config
+        self.build_dir = Path(build_dir) if build_dir else Path(
+            config.get("output", {}).get("final_dir", "output/final")
+        ).parent
+
+        # Derived directories
+        out_cfg = config.get("output", {})
+        narr_cfg = config.get("narration", {})
+        sub_cfg = config.get("subtitles", {})
+        lang_cfg = config.get("languages", {})
+
+        self.clips_dir = Path(out_cfg.get("clips_dir", self.build_dir / "obs"))
+        self.narration_dir = Path(narr_cfg.get("output_dir", self.build_dir / "narration"))
+        self.final_dir = Path(out_cfg.get("final_dir", self.build_dir / "final"))
+
+        sub_template = sub_cfg.get("output_dir", str(self.build_dir / "{lang}" / "subtitles"))
+        self.subtitle_template: str = sub_template
+        self.languages: list[str] = list(lang_cfg.keys()) if lang_cfg else []
+
+        self.tts_engine: str = narr_cfg.get("engine", "edge-tts")
+
+        self.sequences: list[SequenceEntry] = []
+        self.final_video_info: dict = {}
+        self.final_video_path: Optional[Path] = None
+        self.generated_at: str = datetime.now(timezone.utc).isoformat()
+
+    # ------------------------------------------------------------------
+    # Collection
+    # ------------------------------------------------------------------
+
+    def collect(
+        self,
+        seq_ids: Optional[list[str]] = None,
+        project_name: str = "Production",
+        video: Optional[str] = None,
+    ) -> None:
+        """
+        Scan the output directories and populate report data.
+
+        Parameters
+        ----------
+        seq_ids : list[str] | None
+            Ordered list of sequence IDs.  When ``None``, auto-detected from
+            files on disk.
+        project_name : str
+            Project display name (used in headings).
+        video : str | None
+            Video script key (e.g. ``"v01"``) used to locate narration files
+            in sub-directories.
+        """
+        self.project_name = project_name
+        self.video = video
+
+        narr_dir = self.narration_dir
+        if video:
+            narr_dir = narr_dir / video
+
+        # Auto-detect languages from subtitle directories if not in config
+        languages = list(self.languages)
+        if not languages:
+            languages = self._detect_languages(narr_dir)
+
+        # Auto-detect sequence IDs from narration files if not provided
+        if seq_ids is None:
+            seq_ids = self._detect_seq_ids(narr_dir)
+
+        entries: list[SequenceEntry] = []
+        for seq_id in seq_ids:
+            entry = SequenceEntry(seq_id)
+
+            # Clips
+            clip = self._find_clip(seq_id)
+            if clip:
+                entry.clip_path = clip
+                info = _ffprobe_file(clip)
+                entry.clip_duration = info.get("duration", 0.0)
+
+            # Narration
+            narr = narr_dir / f"{seq_id}_narration.mp3"
+            if not narr.exists():
+                narr = narr_dir / f"{seq_id}_narration.wav"
+            if narr.exists():
+                entry.narration_path = narr
+                entry.narration_duration = _mutagen_duration(narr)
+
+            # Subtitles per language
+            for lang in languages:
+                srt_dir = Path(
+                    self.subtitle_template.replace("{lang}", lang)
+                )
+                srt = srt_dir / f"{seq_id}.srt"
+                if srt.exists():
+                    entry.subtitles[lang] = srt
+
+            entries.append(entry)
+
+        self.sequences = entries
+        self.languages_detected = languages
+
+        # Final video
+        self.final_video_path = self._find_final_video(project_name, video)
+        if self.final_video_path:
+            self.final_video_info = _ffprobe_file(self.final_video_path)
+
+    def _detect_seq_ids(self, narr_dir: Path) -> list[str]:
+        """Auto-detect sequence IDs from narration directory."""
+        if not narr_dir.exists():
+            return []
+        ids = sorted(
+            p.stem.replace("_narration", "")
+            for p in narr_dir.glob("*_narration.*")
+            if p.suffix in (".mp3", ".wav")
+        )
+        return ids
+
+    def _detect_languages(self, narr_dir: Path) -> list[str]:
+        """Try to detect languages from subtitle subdirectories."""
+        if self.build_dir.exists():
+            candidates = [
+                d.name for d in self.build_dir.iterdir()
+                if d.is_dir() and len(d.name) in (2, 5) and (d / "subtitles").exists()
+            ]
+            if candidates:
+                return sorted(candidates)
+        return []
+
+    def _find_clip(self, seq_id: str) -> Optional[Path]:
+        """Search for a recording clip for *seq_id*."""
+        for ext in ("*.mkv", "*.mp4"):
+            for p in self.clips_dir.glob(ext):
+                if seq_id in p.name:
+                    return p
+        return None
+
+    def _find_final_video(
+        self, project_name: str, video: Optional[str]
+    ) -> Optional[Path]:
+        """Locate the final assembled video."""
+        if not self.final_dir.exists():
+            return None
+        safe = project_name.lower().replace(" ", "_")
+        pattern = f"{safe}_{video}_final.mp4" if video else f"{safe}_final.mp4"
+        candidate = self.final_dir / pattern
+        if candidate.exists():
+            return candidate
+        # Fallback: any mp4 in final_dir
+        mp4s = sorted(self.final_dir.glob("*.mp4"))
+        return mp4s[-1] if mp4s else None
+
+    # ------------------------------------------------------------------
+    # Display
+    # ------------------------------------------------------------------
+
+    def print_table(self) -> None:
+        """Print the report as a Rich table (or ASCII fallback)."""
+        try:
+            self._print_rich()
+        except ImportError:
+            self._print_ascii()
+
+    def _print_rich(self) -> None:
+        from rich.console import Console  # type: ignore
+        from rich.table import Table  # type: ignore
+        from rich import box  # type: ignore
+
+        console = Console()
+
+        title = f"Narractive Production Report — {getattr(self, 'project_name', 'Production')}"
+        table = Table(
+            title=title,
+            box=box.DOUBLE_EDGE,
+            show_lines=True,
+            caption=f"Generated: {self.generated_at[:19].replace('T', ' ')}",
+        )
+
+        table.add_column("Seq", style="bold cyan", justify="center", no_wrap=True)
+        table.add_column("Clip", justify="right")
+        table.add_column("Narration", justify="right")
+        table.add_column("Subtitles", justify="left")
+
+        total_clip = 0.0
+        total_narr = 0.0
+
+        for entry in self.sequences:
+            clip_s = _fmt_duration(entry.clip_duration) if entry.clip_path else "[dim]-[/dim]"
+            narr_s = _fmt_duration(entry.narration_duration) if entry.narration_path else "[dim]-[/dim]"
+            sub_s = "  ".join(
+                f"[green]{lang}[/green]" if lang in entry.subtitles else f"[red]{lang}[/red]"
+                for lang in getattr(self, "languages_detected", [])
+            ) or "[dim]-[/dim]"
+            table.add_row(entry.seq_id, clip_s, narr_s, sub_s)
+            total_clip += entry.clip_duration
+            total_narr += entry.narration_duration
+
+        table.add_section()
+        lang_line = "  ".join(
+            f"[green]{lang} ok[/green]"
+            if any(lang in e.subtitles for e in self.sequences)
+            else f"[red]{lang} -[/red]"
+            for lang in getattr(self, "languages_detected", [])
+        ) or "[dim]none[/dim]"
+        table.add_row(
+            "[bold]TOTAL[/bold]",
+            f"[bold]{_fmt_duration(total_clip)}[/bold]",
+            f"[bold]{_fmt_duration(total_narr)}[/bold]",
+            lang_line,
+        )
+
+        console.print()
+        console.print(table)
+        console.print(f"  TTS engine  : {self.tts_engine}")
+
+        if self.final_video_path:
+            size_str = _fmt_size(self.final_video_info.get("size", 0))
+            w = self.final_video_info.get("width", 0)
+            h = self.final_video_info.get("height", 0)
+            res = f"{w}x{h}" if w and h else "?"
+            dur = _fmt_duration(self.final_video_info.get("duration", 0))
+            console.print(
+                f"  Final video : {self.final_video_path.name}"
+                f"  ({size_str}, {res}, {dur})"
+            )
+        else:
+            console.print("  Final video : [dim]not found[/dim]")
+        console.print()
+
+    def _print_ascii(self) -> None:
+        """Fallback ASCII table when rich is not installed."""
+        project_name = getattr(self, "project_name", "Production")
+        langs = getattr(self, "languages_detected", [])
+        title = f"Narractive Production Report — {project_name}"
+        width = max(70, len(title) + 4)
+        border = "=" * width
+
+        print(f"\n{border}")
+        print(f"  {title}")
+        print(f"  Generated: {self.generated_at[:19].replace('T', ' ')}")
+        print(border)
+        print(f"  {'Seq':<14}  {'Clip':>8}  {'Narration':>10}  {'Subtitles'}")
+        print("-" * width)
+
+        total_clip = 0.0
+        total_narr = 0.0
+
+        for entry in self.sequences:
+            clip_s = _fmt_duration(entry.clip_duration) if entry.clip_path else "-"
+            narr_s = _fmt_duration(entry.narration_duration) if entry.narration_path else "-"
+            sub_marks = " ".join(
+                f"{lang}:ok" if lang in entry.subtitles else f"{lang}:-"
+                for lang in langs
+            ) or "-"
+            print(f"  {entry.seq_id:<14}  {clip_s:>8}  {narr_s:>10}  {sub_marks}")
+            total_clip += entry.clip_duration
+            total_narr += entry.narration_duration
+
+        print("-" * width)
+        print(f"  {'TOTAL':<14}  {_fmt_duration(total_clip):>8}  {_fmt_duration(total_narr):>10}")
+        print(border)
+        print(f"  TTS engine : {self.tts_engine}")
+
+        if self.final_video_path:
+            size_str = _fmt_size(self.final_video_info.get("size", 0))
+            w = self.final_video_info.get("width", 0)
+            h = self.final_video_info.get("height", 0)
+            res = f"{w}x{h}" if w and h else "?"
+            dur = _fmt_duration(self.final_video_info.get("duration", 0))
+            print(
+                f"  Final video: {self.final_video_path.name}"
+                f"  ({size_str}, {res}, {dur})"
+            )
+        else:
+            print("  Final video: not found")
+        print(border + "\n")
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Return a machine-readable dict (JSON-serialisable)."""
+        total_clip = sum(e.clip_duration for e in self.sequences)
+        total_narr = sum(e.narration_duration for e in self.sequences)
+        total_size = sum(
+            (e.clip_path.stat().st_size if e.clip_path and e.clip_path.exists() else 0)
+            for e in self.sequences
+        )
+        langs = getattr(self, "languages_detected", [])
+
+        result: dict = {
+            "generated_at": self.generated_at,
+            "project_name": getattr(self, "project_name", ""),
+            "tts_engine": self.tts_engine,
+            "languages": langs,
+            "total_sequences": len(self.sequences),
+            "total_clip_duration": round(total_clip, 2),
+            "total_narration_duration": round(total_narr, 2),
+            "total_clips_size_bytes": total_size,
+            "sequences": [e.to_dict() for e in self.sequences],
+        }
+
+        if self.final_video_path:
+            result["final_video"] = {
+                "path": str(self.final_video_path),
+                "size_bytes": self.final_video_info.get("size", 0),
+                "duration": round(self.final_video_info.get("duration", 0.0), 2),
+                "width": self.final_video_info.get("width", 0),
+                "height": self.final_video_info.get("height", 0),
+                "codec_video": self.final_video_info.get("codec_video", ""),
+                "codec_audio": self.final_video_info.get("codec_audio", ""),
+            }
+        else:
+            result["final_video"] = None
+
+        return result

--- a/video_automation/core/tts_base.py
+++ b/video_automation/core/tts_base.py
@@ -1,0 +1,249 @@
+"""
+TTS Engine Plugin Base — Abstract interface for custom TTS engines
+==================================================================
+Defines the :class:`TTSEngine` abstract base class that third-party TTS
+engines must implement, and the :func:`register_tts_engine` /
+:func:`get_tts_engine` registry functions used by :class:`~video_automation.core.narrator.Narrator`.
+
+Quick start::
+
+    from pathlib import Path
+    from video_automation.core.tts_base import TTSEngine, register_tts_engine
+
+    class MyEngine(TTSEngine):
+        engine_name = "my-engine"
+
+        def generate(self, text: str, output_path: Path, lang: str = "fr", **kwargs) -> Path:
+            # ... write audio to output_path ...
+            return output_path
+
+    register_tts_engine(MyEngine)
+
+Then in ``config.yaml``::
+
+    narration:
+      engine: my-engine
+
+Entry-point registration (for installable packages)::
+
+    [project.entry-points."narractive.tts"]
+    my-engine = "my_package.tts_engine:MyEngine"
+
+Entry-point plugins are auto-discovered when :func:`load_entry_point_plugins` is called.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_REGISTRY: dict[str, type["TTSEngine"]] = {}
+
+
+def register_tts_engine(engine_cls: type["TTSEngine"]) -> None:
+    """
+    Register a :class:`TTSEngine` subclass in the global registry.
+
+    Parameters
+    ----------
+    engine_cls : type[TTSEngine]
+        A class with an ``engine_name`` class attribute.
+
+    Raises
+    ------
+    ValueError
+        If ``engine_cls`` does not define a non-empty ``engine_name``.
+    """
+    name = getattr(engine_cls, "engine_name", None)
+    if not name:
+        raise ValueError(
+            f"TTSEngine subclass {engine_cls.__name__} must define a non-empty 'engine_name'."
+        )
+    if name in _REGISTRY:
+        logger.debug("TTS engine '%s' already registered — overwriting with %s", name, engine_cls)
+    _REGISTRY[name] = engine_cls
+    logger.debug("Registered TTS engine: '%s' -> %s", name, engine_cls.__name__)
+
+
+def get_tts_engine(name: str) -> type["TTSEngine"] | None:
+    """
+    Return the registered :class:`TTSEngine` class for *name*, or ``None``.
+
+    Parameters
+    ----------
+    name : str
+        Engine name as declared in ``engine_cls.engine_name``.
+    """
+    return _REGISTRY.get(name)
+
+
+def list_registered_engines() -> list[str]:
+    """Return the names of all registered TTS engines (built-in + plugins)."""
+    return sorted(_REGISTRY.keys())
+
+
+def load_entry_point_plugins() -> None:
+    """
+    Discover and register TTS engine plugins declared via ``narractive.tts``
+    entry points.
+
+    Call this once at startup (it is a no-op if ``importlib.metadata`` is
+    unavailable or no plugins are installed).
+    """
+    try:
+        from importlib.metadata import entry_points
+
+        eps = entry_points(group="narractive.tts")
+        for ep in eps:
+            try:
+                engine_cls = ep.load()
+                register_tts_engine(engine_cls)
+                logger.info("Loaded TTS plugin from entry point '%s': %s", ep.name, engine_cls)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to load TTS plugin '%s': %s", ep.name, exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Entry-point plugin discovery skipped: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Abstract base class
+# ---------------------------------------------------------------------------
+
+
+class TTSEngine(ABC):
+    """
+    Abstract base class for TTS engine plugins.
+
+    Subclasses must:
+
+    1. Set a unique ``engine_name`` class attribute (string).
+    2. Implement :meth:`generate`.
+
+    Optionally override :meth:`get_duration` for format-specific duration
+    probing (the default implementation uses ``mutagen`` or ``ffprobe``).
+
+    Example::
+
+        class ElevenLabsV3Engine(TTSEngine):
+            engine_name = "elevenlabs-v3"
+
+            def generate(self, text, output_path, lang="fr", **kwargs):
+                ...
+                return output_path
+    """
+
+    #: Unique engine identifier used in ``config.yaml`` (``narration.engine``).
+    engine_name: str = ""
+
+    @abstractmethod
+    def generate(self, text: str, output_path: Path, lang: str = "fr", **kwargs) -> Path:
+        """
+        Synthesise *text* and write the audio to *output_path*.
+
+        Parameters
+        ----------
+        text : str
+            Narration text to synthesise.
+        output_path : Path
+            Destination file.  The parent directory is guaranteed to exist.
+        lang : str
+            BCP 47 language code (e.g. ``"fr"``, ``"en"``, ``"pt"``).
+        **kwargs
+            Additional engine-specific keyword arguments forwarded from the
+            ``narration.<engine_name>`` config section.
+
+        Returns
+        -------
+        Path
+            Absolute path to the generated audio file (usually *output_path*).
+        """
+        ...  # pragma: no cover
+
+    def get_duration(self, audio_path: Path) -> float:
+        """
+        Return the duration of *audio_path* in seconds.
+
+        The default implementation tries ``mutagen`` first, then ``ffprobe``.
+        Override for engines that produce formats not supported by mutagen.
+
+        Parameters
+        ----------
+        audio_path : Path
+            Path to the audio file.
+
+        Returns
+        -------
+        float
+            Duration in seconds, or ``0.0`` on failure.
+        """
+        try:
+            from mutagen import File as MutagenFile  # type: ignore
+
+            audio = MutagenFile(str(audio_path))
+            if audio is not None and audio.info is not None:
+                return float(audio.info.length)
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Fallback: ffprobe
+        return _ffprobe_duration(audio_path)
+
+    def validate_config(self, config: dict) -> list[str]:
+        """
+        Validate the engine-specific config section.
+
+        Override to add custom validation.  Return a list of error strings
+        (empty list = valid).
+
+        Parameters
+        ----------
+        config : dict
+            The ``narration.<engine_name>`` section from config.yaml.
+
+        Returns
+        -------
+        list[str]
+            List of validation error messages (empty = valid).
+        """
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def _ffprobe_duration(audio_path: Path) -> float:
+    """Return audio duration via ffprobe, or 0.0 on failure."""
+    import json
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "quiet",
+                "-print_format", "json",
+                "-show_format",
+                str(audio_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            return float(data.get("format", {}).get("duration", 0))
+    except Exception:  # noqa: BLE001
+        pass
+    return 0.0


### PR DESCRIPTION
## Summary

- **Issue #12** — `PipelineState` class (`video_automation/core/pipeline_state.py`): persists run state to `output/.narractive-state.json` (JSON with timestamps). New CLI flags: `--resume` (auto-resume from first non-completed sequence), `--reset` (delete state and start fresh), `--status` (print progress table).
- **Issue #13** — `TTSEngine` ABC (`video_automation/core/tts_base.py`): abstract base class + registry (`register_tts_engine`, `get_tts_engine`). `Narrator` dispatches to plugins for unknown engine names. Entry-point auto-discovery via `narractive.tts` group. Example plugin: `examples/custom_tts_plugin.py` (`SilenceTTSEngine`).
- **Issue #14** — `ProductionReport` + `narractive report` command (`video_automation/core/report.py`): scans clips, narration audio, subtitles, final video; Rich table output with ASCII fallback; `--json` / `--output` flags. Optional dep: `pip install narractive[report]`.

## Files changed

- `video_automation/core/pipeline_state.py` — new PipelineState class
- `video_automation/core/tts_base.py` — TTSEngine ABC + registry
- `video_automation/core/report.py` — ProductionReport class
- `video_automation/core/narrator.py` — plugin dispatch + register_tts_engine re-export
- `video_automation/cli.py` — --resume / --reset / --status flags + `report` subcommand
- `examples/custom_tts_plugin.py` — SilenceTTSEngine example plugin
- `pyproject.toml` — add `report` optional dep (rich>=13.0)
- `tests/test_sprint5.py` — 51 new unit tests

## Test plan

- [x] `python3 -m pytest tests/test_sprint5.py -v` — 51 passed
- [x] `python3 -m pytest tests/` — 418 passed, 3 pre-existing failures (unrelated), 0 regressions
- [ ] Manual: `narractive --all --resume` after interrupted run
- [ ] Manual: `narractive --status` during/after a run
- [ ] Manual: `narractive report output/ --json`
- [ ] Manual: register custom plugin via entry-point and confirm it's discovered

Closes #12
Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)